### PR TITLE
Fix openldap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ GoDoc available here: http://godoc.org/github.com/szferi/gomdb
 Build
 =======
 
-`git clone -b mdb.master --single-branch git://git.openldap.org/openldap.git`
-
-`make`
-
-`make install`
+```bash
+git clone -b mdb.master --single-branch git://git.openldap.org/openldap.git
+cd openldap/libraries/liblmdb
+make
+make install
+```
 
 It will install to /usr/local
 


### PR DESCRIPTION
The Makefile (on the mdb.master branch) of the openldap.git repo is
under `libraries/liblmdb`. I have tested that you can `make` and `make
install` from there, and I'm assuming that's what this section is trying
to do. Perhaps the upstream repo shuffled some code around?